### PR TITLE
Added upper- and lowercase Greek and Hebrew letter names.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -140,6 +140,59 @@ const lowerAlphabets = [
 const upperAlphabets = [
   "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
 ];
+const upperGreek = [
+  "Alpha",
+  "Beta",
+  "Gamma",
+  "Delta",
+  "Epsilon",
+  "Zeta",
+  "Eta",
+  "Theta",
+  "Iota",
+  "Kappa",
+  "Lambda",
+  "Mu",
+  "Nu",
+  "Xi",
+  "Omicron",
+  "Pi",
+  "Rho",
+  "Sigma",
+  "Tau",
+  "Upsilon",
+  "Phi",
+  "Chi",
+  "Psi",
+  "Omega",
+];
+const lowerGreek = upperGreek.map(x => x.toLocaleLowerCase());
+
+const upperHebrew = [
+  "Alef",
+  "Bet",
+  "Gimel",
+  "Dalet",
+  "He",
+  "Vav",
+  "Zayin",
+  "Chet",
+  "Tet",
+  "Yod",
+  "Kaf",
+  "Lamed",
+  "Mem",
+  "Nun",
+  "Samech",
+  "Ayin",
+  "Pe",
+  "Tsadi",
+  "Qof",
+  "Resh",
+  "Shin",
+  "Tav",
+];
+const lowerHebrew = upperHebrew.map(x => x.toLocaleLowerCase());
 
 const days = [
   "Sunday",
@@ -279,5 +332,6 @@ const sequenceListAry = [
   daysShort, daysShortLower, days, daysLower,
   monthsShort, monthsShortLower, months, monthsLower,
   metaVar, metaVarJp, dummyNames, dummyNamesLower,
+  lowerGreek, upperGreek, lowerHebrew, upperHebrew
 ];
 


### PR DESCRIPTION
This adds both upper-and lowercase Greek and Hebrew alphabet letter-names as items that can be filled in automatically. This is useful for labeling things in sequence, e.g., "alpha, beta, gamma..." or "alef, bet, gimel...".

The order of items in `sequenceListAry` is carefully chosen so the user can access any of the options. By typing simply 'a', they get the Roman alphabet; typing 'al' gives the dummy names, 'alp' then gives the Greek alphabet or 'ale' gives the Hebrew alphabet.